### PR TITLE
Update mlvpn.c to make it work for uClibc1.014_eabi of my  armv7 CPU

### DIFF
--- a/src/mlvpn.c
+++ b/src/mlvpn.c
@@ -200,7 +200,8 @@ void preset_permitted(int argc, char **argv)
   mlvpn_tunnel_t *t;
   char tunname[21];
   uint64_t val=0;
-  char c, mag=0;
+  int c;
+  char mag=0;
   int filled, option_index;
   optind=0;
     while(1)


### PR DESCRIPTION
c = getopt_long(argc, argv, optstr, long_options, &option_index);  when c is char type it will return -1 in x86 and mips CPU but it will return 255 all the time and I never get -1 in my armv7 CPU with uClibc1.014_eabi  .  So the  program will blocked in preset_permitted() and never go next. But when I correct the c as int type. It works fine for me.